### PR TITLE
Makes use of assertArraysAlmostEqual

### DIFF
--- a/homework1.4/test.py
+++ b/homework1.4/test.py
@@ -8,7 +8,7 @@ class TestSequenceFunctions(unittest.TestCase):
 
     task.colors = [['green','green','green'],
                    ['green','red','green'],
-                   ['green','green','green']]	
+                   ['green','green','green']]
     task.measurements=['red']
     task.motions=[[0,0]]
     task.sensor_right=1.0
@@ -16,14 +16,14 @@ class TestSequenceFunctions(unittest.TestCase):
 
     p = task.calculate()
 
-    self.assertEqual(expected_result, p)
+    self.assertAlmostEqual(expected_result, p)
 
   def test_dataset2(self):
     expected_result=[[0,0,0],[0,0.5,0.5],[0,0,0]]
 
     task.colors = [['green','green','green'],
                    ['green','red','red'],
-                   ['green','green','green']]	
+                   ['green','green','green']]
     task.measurements=['red']
     task.motions=[[0,0]]
     task.sensor_right=1.0
@@ -38,7 +38,7 @@ class TestSequenceFunctions(unittest.TestCase):
 
     task.colors = [['green','green','green'],
                    ['green','red','red'],
-                   ['green','green','green']]	
+                   ['green','green','green']]
     task.measurements=['red']
     task.motions=[[0,0]]
     task.sensor_right=0.8
@@ -63,7 +63,7 @@ class TestSequenceFunctions(unittest.TestCase):
 
     task.colors = [['green', 'green', 'green'],
                    ['green', 'red', 'red'],
-                   ['green', 'green', 'green']]	
+                   ['green', 'green', 'green']]
     task.measurements=['red', 'red']
     task.motions=[[0,0], [0, 1]]
     task.sensor_right=0.8
@@ -88,7 +88,7 @@ class TestSequenceFunctions(unittest.TestCase):
 
     task.colors = [['green', 'green', 'green'],
                    ['green', 'red', 'red'],
-                   ['green', 'green', 'green']]	
+                   ['green', 'green', 'green']]
     task.measurements=['red', 'red']
     task.motions=[[0,0], [0, 1]]
     task.sensor_right=1.0
@@ -105,7 +105,7 @@ class TestSequenceFunctions(unittest.TestCase):
 
     task.colors = [['green', 'green', 'green'],
                    ['green', 'red', 'red'],
-                   ['green', 'green', 'green']]	
+                   ['green', 'green', 'green']]
     task.measurements=['red', 'red']
     task.motions=[[0,0], [0, 1]]
     task.sensor_right=.8
@@ -119,9 +119,7 @@ class TestSequenceFunctions(unittest.TestCase):
 
     for i in range(len(expected_result)):
       for j in range(len(expected_result[1])):
-        expected_result[i][j] = round(expected_result[i][j],4)
-
-    self.assertEqual(expected_result, p)
+        self.assertAlmostEqual(expected_result[i][j], p[i][j], 4)
 
   def test_dataset7(self):
     expected_result=[[0.0, 0.0, 0.0],
@@ -130,7 +128,7 @@ class TestSequenceFunctions(unittest.TestCase):
 
     task.colors = [['green', 'green', 'green'],
                    ['green', 'red', 'red'],
-                   ['green', 'green', 'green']]	
+                   ['green', 'green', 'green']]
     task.measurements=['red', 'red']
     task.motions=[[0,0], [0, 1]]
     task.sensor_right=1.0
@@ -144,11 +142,9 @@ class TestSequenceFunctions(unittest.TestCase):
 
     for i in range(len(expected_result)):
       for j in range(len(expected_result[1])):
-        expected_result[i][j] = round(expected_result[i][j],4)
+        self.assertAlmostEqual(expected_result[i][j], p[i][j], 4)
 
-    self.assertEqual(expected_result, p)
 
- 
   def test_dataset8(self):
     expected_result=[[0.01105, 0.02464, 0.06799, 0.04472, 0.024651],
                      [0.00715, 0.01017, 0.08696, 0.07988, 0.00935],
@@ -158,7 +154,7 @@ class TestSequenceFunctions(unittest.TestCase):
     task.colors = [['red','green', 'green', 'red','red'],
                    ['red','red','green', 'red', 'red'],
                    ['red','red','green', 'green', 'red'],
-                   ['red','red','red','red','red']]	
+                   ['red','red','red','red','red']]
     task.measurements=['green','green','green','green','green']
     task.motions=[[0,0], [0, 1], [1, 0], [1, 0], [0, 1]]
     task.sensor_right=0.7
@@ -167,13 +163,8 @@ class TestSequenceFunctions(unittest.TestCase):
     p = task.calculate()
 
     for i in range(len(p)):
-      for j in range(len(p[1])):
-        p[i][j] = round(p[i][j],4)
+      for j in range(len(p[0])):
+        self.assertAlmostEqual(p[i][j], expected_result[i][j], 4)
 
-    for i in range(len(expected_result)):
-      for j in range(len(expected_result[1])):
-        expected_result[i][j] = round(expected_result[i][j],4)
-
-    self.assertEqual(expected_result, p)
 if __name__ == '__main__':
   unittest.main()

--- a/homework1.4/test.py
+++ b/homework1.4/test.py
@@ -2,8 +2,31 @@ import unittest
 import task
 
 class TestSequenceFunctions(unittest.TestCase):
+  def failUnlessArraysAlmostEqual(self, first, second, places=7, msg=None):
+      """Fail if the two arrays are unequal as determined by their
+         difference rounded to the given number of decimal places
+         (default 7) and comparing to zero.
+
+         Note that decimal places (from zero) are usually not the same
+         as significant digits (measured from the most signficant digit).
+      """
+      if (len(first) != len(second)):
+          raise self.failureException, \
+              (msg or '%r != %r because they have unequal lengths %d & %d', \
+                  (first, second, len(first), len(second)))
+
+      for i in range(len(first)):
+          if isinstance(first[i], list):
+            self.failUnlessArraysAlmostEqual(first[i], second[i], places, msg)
+          elif round(abs(second[i]-first[i]), places) != 0:
+              raise self.failureException, \
+                (msg or '%r != %r within %r places' % (first, second, places))
+
+  # Synonym methods
+  assertArrayAlmostEqual = assertArrayAlmostEquals = failUnlessArraysAlmostEqual
 
   def test_dataset1(self):
+    # ARRANGE
     expected_result=[[0,0,0],[0,1,0],[0,0,0]]
 
     task.colors = [['green','green','green'],
@@ -14,11 +37,14 @@ class TestSequenceFunctions(unittest.TestCase):
     task.sensor_right=1.0
     task.p_move=1.0
 
+    # ACT
     p = task.calculate()
 
-    self.assertAlmostEqual(expected_result, p)
+    # ASSERT
+    self.assertArrayAlmostEquals(expected_result, p)
 
   def test_dataset2(self):
+    # ARRANGE
     expected_result=[[0,0,0],[0,0.5,0.5],[0,0,0]]
 
     task.colors = [['green','green','green'],
@@ -29,11 +55,14 @@ class TestSequenceFunctions(unittest.TestCase):
     task.sensor_right=1.0
     task.p_move=1.0
 
+    # ACT
     p = task.calculate()
 
-    self.assertEqual(expected_result, p)
+    # ASSERT
+    self.assertArrayAlmostEquals(expected_result, p)
 
   def test_dataset3(self):
+    # ARRANGE
     expected_result=[[0.06666,0.06666, 0.06666],[0.06666,0.26666,0.26666],[0.06666,0.06666,0.06666]]
 
     task.colors = [['green','green','green'],
@@ -44,19 +73,14 @@ class TestSequenceFunctions(unittest.TestCase):
     task.sensor_right=0.8
     task.p_move=1.0
 
+    # ACT
     p = task.calculate()
 
-    for i in range(len(p)):
-      for j in range(len(p[1])):
-        p[i][j] = round(p[i][j],4)
-
-    for i in range(len(expected_result)):
-      for j in range(len(expected_result[1])):
-        expected_result[i][j] = round(expected_result[i][j],4)
-
-    self.assertEqual(expected_result, p)
+    # ASSERT
+    self.assertArrayAlmostEquals(expected_result, p, 4)
 
   def test_dataset4(self):
+    # ARRANGE
     expected_result=[[0.03333, 0.03333, 0.03333],
                      [0.13333, 0.13333, 0.53333],
                      [0.03333, 0.03333, 0.03333]]
@@ -69,19 +93,14 @@ class TestSequenceFunctions(unittest.TestCase):
     task.sensor_right=0.8
     task.p_move=1.0
 
+    # ACT
     p = task.calculate()
 
-    for i in range(len(p)):
-      for j in range(len(p[1])):
-        p[i][j] = round(p[i][j],4)
-
-    for i in range(len(expected_result)):
-      for j in range(len(expected_result[1])):
-        expected_result[i][j] = round(expected_result[i][j],4)
-
-    self.assertEqual(expected_result, p)
+    # ASSERT
+    self.assertArrayAlmostEquals(expected_result, p, 4)
 
   def test_dataset5(self):
+    # ARRANGE
     expected_result=[[0.0, 0.0, 0.0],
                      [0.0, 0.0, 1.0],
                      [0.0, 0.0, 0.0]]
@@ -94,11 +113,14 @@ class TestSequenceFunctions(unittest.TestCase):
     task.sensor_right=1.0
     task.p_move=1.0
 
+    # ACT
     p = task.calculate()
 
-    self.assertEqual(expected_result, p)
+    # ASSERT
+    self.assertArrayAlmostEquals(expected_result, p, 4)
 
   def test_dataset6(self):
+    # ARRANGE
     expected_result=[[0.02898, 0.02898, 0.02898],
                      [0.07246, 0.28985, 0.46376],
                      [0.02898, 0.02898, 0.02898]]
@@ -111,17 +133,14 @@ class TestSequenceFunctions(unittest.TestCase):
     task.sensor_right=.8
     task.p_move=0.5
 
+    # ACT
     p = task.calculate()
 
-    for i in range(len(p)):
-      for j in range(len(p[1])):
-        p[i][j] = round(p[i][j],4)
-
-    for i in range(len(expected_result)):
-      for j in range(len(expected_result[1])):
-        self.assertAlmostEqual(expected_result[i][j], p[i][j], 4)
+    # ASSERT
+    self.assertArrayAlmostEquals(expected_result, p, 4)
 
   def test_dataset7(self):
+    # ARRANGE
     expected_result=[[0.0, 0.0, 0.0],
                      [0.0, 0.33333, 0.66666],
                      [0.0, 0.0, 0.0]]
@@ -134,18 +153,15 @@ class TestSequenceFunctions(unittest.TestCase):
     task.sensor_right=1.0
     task.p_move=0.5
 
+    # ACT
     p = task.calculate()
 
-    for i in range(len(p)):
-      for j in range(len(p[1])):
-        p[i][j] = round(p[i][j],4)
-
-    for i in range(len(expected_result)):
-      for j in range(len(expected_result[1])):
-        self.assertAlmostEqual(expected_result[i][j], p[i][j], 4)
+    # ASSERT
+    self.assertArrayAlmostEquals(expected_result, p, 4)
 
 
   def test_dataset8(self):
+    # ARRANGE
     expected_result=[[0.01105, 0.02464, 0.06799, 0.04472, 0.024651],
                      [0.00715, 0.01017, 0.08696, 0.07988, 0.00935],
                      [0.00739, 0.00894, 0.11272, 0.35350, 0.04065],
@@ -160,11 +176,11 @@ class TestSequenceFunctions(unittest.TestCase):
     task.sensor_right=0.7
     task.p_move=0.8
 
+    # ACT
     p = task.calculate()
 
-    for i in range(len(p)):
-      for j in range(len(p[0])):
-        self.assertAlmostEqual(p[i][j], expected_result[i][j], 4)
+    # ASSERT
+    self.assertArrayAlmostEquals(expected_result, p, 4)
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
The modified version of the test makes use of a method similar to assertAlmostEqual instead of explicitly rounding off expected and actual values for floating point comparison.

Based on the discussion here: http://www.udacity-forums.com/cs373/questions/1942/unit-tests-for-homework-14, probably the tests were written for python 2.6.

I have tested the new code with both python 2.6 and 2.7, and everything works!
