### PR TITLE
Adapt policy check so that alternative valid policies check out.

### DIFF
--- a/homework4.5/test.py
+++ b/homework4.5/test.py
@@ -19,10 +19,9 @@ class TestMotion(unittest.TestCase):
             self.assertEqual(len(expected[i]), len(got[i]),
                 "Policy lists have different size: expected %d, got %d in line %d" % (len(expected[i]), len(got[i]), i))
             for j, _ in enumerate(row):
-                self.assertEqual(expected[i][j],
-                                 got[i][j],
+                self.assertTrue(got[i][j] in expected[i][j],
                                  "Policies differ: expected %s, got %s at [%d][%d]" % (expected[i][j], got[i][j], i, j))
-        self.assertEqual(expected, got)
+        #self.assertEqual(expected, got)
 
     def test_small_1(self):
         exp_value = [[60.472, 37.193, 0.000],
@@ -77,10 +76,10 @@ class TestMotion(unittest.TestCase):
                      [4.000, 3.000, 2.000, 1.000],
                      [5.000, 4.000, 3.000, 2.000],
                      [6.000, 1000.000, 1000.000, 3.000]]
-        exp_policy = [['>', '>', '>', '*'],
-                      ['^', '^', '^', '^'],
-                      ['^', '^', '^', '^'],
-                      ['^', ' ', ' ', '^']]
+        exp_policy = [['>',  '>',  '>',  '*'],
+                      ['^>', '^>', '^>', '^'],
+                      ['^>', '^>', '^>', '^'],
+                      ['^',  ' ',  ' ',  '^']]
         task.grid = [[0, 0, 0, 0],
                      [0, 0, 0, 0],
                      [0, 0, 0, 0],


### PR DESCRIPTION
Given a value matrix of something like

```
2 1
1 0
```

then both the policies

```
> v         v v
> *         > *
```

are valid. This patch allows for such alternatives.
