### PR TITLE
This isn't huge, but might help people while they are debugging failures.

### DIFF
--- a/homework6.3/test.py
+++ b/homework6.3/test.py
@@ -63,7 +63,9 @@ class SLAMTest(unittest.TestCase):
         for i, (xrow, yrow) in enumerate(zip(x.value, y.value)):
             for j, (xel, yel) in enumerate(zip(xrow, yrow)):
                 self.assertAlmostEqual(xel, yel, precision,
-                                       "The element at (%d, %d) in %s matrix differs: expected %.3f, got %.3f" % (i, j, name, xel, yel))
+                                       ("The element at (%d, %d) in %s matrix differs: expected %." + 
+                                        str(precision+1) + "f, got %." + str(precision+1) + 
+                                        "f") % (i, j, name, xel, yel))
 
     def solution_check(self, result, answer_mu, answer_omega):
         self.assertTrue(len(result) == 2,


### PR DESCRIPTION
I changed the number of decimal places printed for a failure from a
fixed "3" to the precision being tested +1. 

This will allow it to work with any other level of precision that is
passed in to the function.  In addition it will show errors where they
are only different by a rounded part (causing the assertion, but looking
the same).  For example 3.1415 and 3.1414 will throw an assertion (round
to 3.142 and 3.141) but will both print as 3.141 with %.3f.  ...%." +
str(precision) + "f... will print the extra digit that determines
rounding.
